### PR TITLE
feat: add script to upsert Mundial 2026 players and update GroupDashb…

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "lib/firestore-rules.js"
+  },
   "functions": [
     {
       "source": "functions",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,11 +1,178 @@
-import { onRequest } from "firebase-functions/v2/https";
+import { HttpsError, onCall, onRequest } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
 import axios from "axios";
+import admin from "firebase-admin";
+
+if (admin.apps.length === 0) {
+    admin.initializeApp();
+}
 
 // REEMPLAZA ESTOS VALORES CON LOS DE TU PANEL DE META
 const WHATSAPP_TOKEN = "EAAMXqaULMtABRF6oECq7Gxy0zCNKmTOscqNKrm9j3OmCTZBYBK7DCoBZChB4PAqFYgibVF9u8DnfWSY9g5s6sygZCZCCOvtOfM8q24kGckdkDzyf9a3XGySXYgGRZBbCYcwPyyLb29TNzdf4CU4FVflwGfJlXsquZCZBWc1UhAmvtSivkWuyFpG0oJb7K4lZCQZDZD";
 const PHONE_NUMBER_ID = "977909532082603"; // El ID que sale en tu imagen
 const VERSION = "v22.0";
+
+type GroupData = {
+    id: string;
+    adminUid: string;
+    participants?: string[];
+    competitionId: string;
+    settings: {
+        pointsExactScore: number;
+        pointsWinner: number;
+        pointsGoalDifference?: number;
+    };
+};
+
+type PredictionData = {
+    id: string;
+    userId: string;
+    matchId: string;
+    team1Score: number;
+    team2Score: number;
+    points?: number;
+};
+
+type MatchData = {
+    id: string;
+    result?: {
+        team1Score: number;
+        team2Score: number;
+    };
+};
+
+function calculatePredictionPoints(
+    prediction: PredictionData,
+    matchResult: { team1Score: number; team2Score: number },
+    settings: GroupData["settings"]
+) {
+    let points = 0;
+    const predDiff = prediction.team1Score - prediction.team2Score;
+    const resultDiff = matchResult.team1Score - matchResult.team2Score;
+    const predWinner = predDiff > 0 ? 1 : predDiff < 0 ? 2 : 0;
+    const resultWinner = resultDiff > 0 ? 1 : resultDiff < 0 ? 2 : 0;
+
+    if (
+        prediction.team1Score === matchResult.team1Score &&
+        prediction.team2Score === matchResult.team2Score
+    ) {
+        points += settings.pointsExactScore;
+        if (settings.pointsWinner > 0 && resultWinner !== 0) points += settings.pointsWinner;
+        if (settings.pointsGoalDifference) points += settings.pointsGoalDifference;
+        return points;
+    }
+
+    if (predWinner === resultWinner && resultWinner !== 0) points += settings.pointsWinner;
+    if (settings.pointsGoalDifference && predDiff === resultDiff) points += settings.pointsGoalDifference;
+    return points;
+}
+
+async function buildGroupLeaderboard(groupId: string) {
+    const db = admin.firestore();
+    const groupSnap = await db.collection("groups").doc(groupId).get();
+    if (!groupSnap.exists) throw new Error(`Group not found: ${groupId}`);
+
+    const group = { id: groupSnap.id, ...groupSnap.data() } as GroupData;
+    const userIds = [...new Set([...(group.participants ?? []), group.adminUid].filter(Boolean))];
+
+    const [matchesSnap, predictionsSnap, bonusSnap, usersSnap] = await Promise.all([
+        db
+            .collection("competitions")
+            .doc(group.competitionId)
+            .collection("matches")
+            .where("status", "==", "finished")
+            .get(),
+        db.collection("groups").doc(groupId).collection("predictions").get(),
+        db.collection("groups").doc(groupId).collection("bonusPredictions").get(),
+        Promise.all(userIds.map((userId) => db.collection("users").doc(userId).get()))
+    ]);
+
+    const matches = new Map<string, MatchData>();
+    matchesSnap.forEach((doc) => matches.set(doc.id, { id: doc.id, ...doc.data() } as MatchData));
+
+    const totals = new Map<string, { matchPoints: number; bonusPoints: number; predictionsCount: number }>();
+    userIds.forEach((userId) => totals.set(userId, { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 }));
+
+    predictionsSnap.forEach((doc) => {
+        const prediction = { id: doc.id, ...doc.data() } as PredictionData;
+        const match = matches.get(prediction.matchId);
+        if (!match?.result) return;
+        const total = totals.get(prediction.userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+        total.matchPoints += calculatePredictionPoints(prediction, match.result, group.settings);
+        total.predictionsCount += 1;
+        totals.set(prediction.userId, total);
+    });
+
+    bonusSnap.forEach((doc) => {
+        const bonus = doc.data() as { userId?: string; points?: number };
+        if (!bonus.userId) return;
+        const total = totals.get(bonus.userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+        total.bonusPoints += bonus.points ?? 0;
+        totals.set(bonus.userId, total);
+    });
+
+    const users = new Map<string, FirebaseFirestore.DocumentData>();
+    usersSnap.forEach((snap) => {
+        if (snap.exists) users.set(snap.id, snap.data() ?? {});
+    });
+
+    const entries = userIds.map((userId) => {
+        const user = users.get(userId);
+        const total = totals.get(userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+        return {
+            userId,
+            userName: user?.displayName ?? `Usuario ${userId.substring(0, 8)}...`,
+            avatarUrl: user?.avatarUrl ?? null,
+            totalPoints: total.matchPoints + total.bonusPoints,
+            predictionsCount: total.predictionsCount,
+            rank: 0
+        };
+    });
+
+    entries.sort((a, b) =>
+        b.totalPoints !== a.totalPoints ? b.totalPoints - a.totalPoints : a.userName.localeCompare(b.userName)
+    );
+    entries.forEach((entry, index) => {
+        entry.rank = index + 1;
+    });
+
+    await db.collection("groups").doc(groupId).collection("leaderboard").doc("main").set({
+        entries,
+        participantsCount: userIds.length,
+        finishedMatchesCount: matches.size,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+}
+
+export const refreshLeaderboards = onCall({ cors: true }, async (request) => {
+    if (!request.auth) {
+        throw new HttpsError("unauthenticated", "Debes iniciar sesión.");
+    }
+
+    const competitionId = String(request.data?.competitionId ?? "").trim();
+    if (!competitionId) {
+        throw new HttpsError("invalid-argument", "competitionId es requerido.");
+    }
+
+    const db = admin.firestore();
+    const userSnap = await db.collection("users").doc(request.auth.uid).get();
+    if (userSnap.data()?.superAdmin !== true) {
+        throw new HttpsError("permission-denied", "No tienes permisos para actualizar tablas.");
+    }
+
+    const groupsSnap = await db.collection("groups").where("competitionId", "==", competitionId).get();
+    for (const groupDoc of groupsSnap.docs) {
+        await buildGroupLeaderboard(groupDoc.id);
+    }
+
+    logger.info("Leaderboards refreshed", {
+        competitionId,
+        groupsUpdated: groupsSnap.size,
+        requestedBy: request.auth.uid
+    });
+
+    return { groupsUpdated: groupsSnap.size };
+});
 
 export const whatsappWebhook = onRequest({ invoker: "public" }, async (req, res) => {
     // 1. VALIDACIÓN GET (Ya la tienes bien)

--- a/lib/firestore-rules.js
+++ b/lib/firestore-rules.js
@@ -198,6 +198,14 @@ service cloud.firestore {
         
         allow delete: if false;
       }
+
+      // ============================================
+      // LEADERBOARD AGGREGATES
+      // ============================================
+      match /leaderboard/{leaderboardId} {
+        allow read: if isAuthenticated() && isGroupParticipant(groupId);
+        allow write: if false;
+      }
     }
     
     // ============================================
@@ -210,16 +218,19 @@ service cloud.firestore {
       // Crear: solo el mismo usuario al registrarse
       // IMPORTANTE: canCreateGroups debe ser false por defecto
       allow create: if isAuthenticated() && 
-                       request.auth.uid == userId &&
-                       request.resource.data.canCreateGroups == false;
+                        request.auth.uid == userId &&
+                        request.resource.data.canCreateGroups == false &&
+                        (!request.resource.data.keys().hasAny(['superAdmin']) ||
+                         request.resource.data.superAdmin == false);
       
       // Actualizar: solo el mismo usuario
       // IMPORTANTE: canCreateGroups no puede pasarse de false a true (solo admin/script).
       // Pero SÍ se permite pasar de true a false (cuando createGroup consume el último slot).
       allow update: if isAuthenticated() && 
-                       request.auth.uid == userId &&
-                       (request.resource.data.diff(resource.data).affectedKeys().hasAny(['canCreateGroups']) == false ||
-                        (resource.data.canCreateGroups == true && request.resource.data.canCreateGroups == false));
+                        request.auth.uid == userId &&
+                        request.resource.data.diff(resource.data).affectedKeys().hasAny(['superAdmin']) == false &&
+                        (request.resource.data.diff(resource.data).affectedKeys().hasAny(['canCreateGroups']) == false ||
+                         (resource.data.canCreateGroups == true && request.resource.data.canCreateGroups == false));
     }
     
   }

--- a/scripts/build-group-leaderboard.ts
+++ b/scripts/build-group-leaderboard.ts
@@ -1,0 +1,202 @@
+/**
+ * Builds the cheap leaderboard aggregate used by the client.
+ *
+ * Usage:
+ *   npx tsx scripts/build-group-leaderboard.ts <groupId>
+ *   npx tsx scripts/build-group-leaderboard.ts --competition <competitionId>
+ */
+
+import admin from 'firebase-admin';
+import dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+dotenv.config();
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectId = process.env.PUBLIC_FIREBASE_PROJECT_ID;
+
+if (!projectId) {
+  console.error('❌ PUBLIC_FIREBASE_PROJECT_ID is missing.');
+  process.exit(1);
+}
+
+function initializeFirebaseAdmin() {
+  if (admin.apps.length > 0) return;
+
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (credPath) {
+    const serviceAccount = JSON.parse(readFileSync(credPath, 'utf8')) as admin.ServiceAccount;
+    admin.initializeApp({ credential: admin.credential.cert(serviceAccount), projectId });
+    return;
+  }
+
+  const serviceAccount = JSON.parse(
+    readFileSync(join(__dirname, 'service-account-key.json'), 'utf8')
+  ) as admin.ServiceAccount;
+  admin.initializeApp({ credential: admin.credential.cert(serviceAccount), projectId });
+}
+
+type GroupData = {
+  id: string;
+  adminUid: string;
+  participants: string[];
+  competitionId: string;
+  settings: {
+    pointsExactScore: number;
+    pointsWinner: number;
+    pointsGoalDifference?: number;
+  };
+};
+
+type PredictionData = {
+  id: string;
+  userId: string;
+  matchId: string;
+  team1Score: number;
+  team2Score: number;
+  points?: number;
+};
+
+type MatchData = {
+  id: string;
+  status: string;
+  result?: {
+    team1Score: number;
+    team2Score: number;
+  };
+};
+
+function calculatePredictionPoints(
+  prediction: PredictionData,
+  matchResult: { team1Score: number; team2Score: number },
+  settings: GroupData['settings']
+) {
+  let points = 0;
+  const predDiff = prediction.team1Score - prediction.team2Score;
+  const resultDiff = matchResult.team1Score - matchResult.team2Score;
+  const predWinner = predDiff > 0 ? 1 : predDiff < 0 ? 2 : 0;
+  const resultWinner = resultDiff > 0 ? 1 : resultDiff < 0 ? 2 : 0;
+
+  if (
+    prediction.team1Score === matchResult.team1Score &&
+    prediction.team2Score === matchResult.team2Score
+  ) {
+    points += settings.pointsExactScore;
+    if (settings.pointsWinner > 0 && resultWinner !== 0) points += settings.pointsWinner;
+    if (settings.pointsGoalDifference) points += settings.pointsGoalDifference;
+    return points;
+  }
+
+  if (predWinner === resultWinner && resultWinner !== 0) points += settings.pointsWinner;
+  if (settings.pointsGoalDifference && predDiff === resultDiff) points += settings.pointsGoalDifference;
+  return points;
+}
+
+async function buildGroupLeaderboard(groupId: string) {
+  const db = admin.firestore();
+  const groupSnap = await db.collection('groups').doc(groupId).get();
+  if (!groupSnap.exists) throw new Error(`Group not found: ${groupId}`);
+
+  const group = { id: groupSnap.id, ...groupSnap.data() } as GroupData;
+  const userIds = [...new Set([...(group.participants ?? []), group.adminUid].filter(Boolean))];
+
+  const [matchesSnap, predictionsSnap, bonusSnap, usersSnap] = await Promise.all([
+    db
+      .collection('competitions')
+      .doc(group.competitionId)
+      .collection('matches')
+      .where('status', '==', 'finished')
+      .get(),
+    db.collection('groups').doc(groupId).collection('predictions').get(),
+    db.collection('groups').doc(groupId).collection('bonusPredictions').get(),
+    Promise.all(userIds.map((userId) => db.collection('users').doc(userId).get()))
+  ]);
+
+  const matches = new Map<string, MatchData>();
+  matchesSnap.forEach((doc) => matches.set(doc.id, { id: doc.id, ...doc.data() } as MatchData));
+
+  const totals = new Map<string, { matchPoints: number; bonusPoints: number; predictionsCount: number }>();
+  userIds.forEach((userId) => totals.set(userId, { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 }));
+
+  predictionsSnap.forEach((doc) => {
+    const prediction = { id: doc.id, ...doc.data() } as PredictionData;
+    const match = matches.get(prediction.matchId);
+    if (!match?.result) return;
+    const total = totals.get(prediction.userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+    total.matchPoints += calculatePredictionPoints(prediction, match.result, group.settings);
+    total.predictionsCount += 1;
+    totals.set(prediction.userId, total);
+  });
+
+  bonusSnap.forEach((doc) => {
+    const bonus = doc.data() as { userId?: string; points?: number };
+    if (!bonus.userId) return;
+    const total = totals.get(bonus.userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+    total.bonusPoints += bonus.points ?? 0;
+    totals.set(bonus.userId, total);
+  });
+
+  const users = new Map<string, FirebaseFirestore.DocumentData>();
+  usersSnap.forEach((snap) => {
+    if (snap.exists) users.set(snap.id, snap.data() ?? {});
+  });
+
+  const entries = userIds.map((userId) => {
+    const user = users.get(userId);
+    const total = totals.get(userId) ?? { matchPoints: 0, bonusPoints: 0, predictionsCount: 0 };
+    return {
+      userId,
+      userName: user?.displayName ?? `Usuario ${userId.substring(0, 8)}...`,
+      avatarUrl: user?.avatarUrl ?? null,
+      totalPoints: total.matchPoints + total.bonusPoints,
+      predictionsCount: total.predictionsCount,
+      rank: 0
+    };
+  });
+
+  entries.sort((a, b) =>
+    b.totalPoints !== a.totalPoints ? b.totalPoints - a.totalPoints : a.userName.localeCompare(b.userName)
+  );
+  entries.forEach((entry, index) => {
+    entry.rank = index + 1;
+  });
+
+  await db.collection('groups').doc(groupId).collection('leaderboard').doc('main').set({
+    entries,
+    participantsCount: userIds.length,
+    finishedMatchesCount: matches.size,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp()
+  });
+
+  console.log(`✅ Leaderboard aggregate written for ${groupId}: ${entries.length} entries.`);
+}
+
+async function main() {
+  initializeFirebaseAdmin();
+
+  const [, , firstArg, secondArg] = process.argv;
+  if (!firstArg) {
+    console.error('Usage: npx tsx scripts/build-group-leaderboard.ts <groupId>');
+    console.error('   or: npx tsx scripts/build-group-leaderboard.ts --competition <competitionId>');
+    process.exit(1);
+  }
+
+  if (firstArg === '--competition') {
+    if (!secondArg) throw new Error('Competition id is required.');
+    const db = admin.firestore();
+    const groupsSnap = await db.collection('groups').where('competitionId', '==', secondArg).get();
+    for (const groupDoc of groupsSnap.docs) {
+      await buildGroupLeaderboard(groupDoc.id);
+    }
+    return;
+  }
+
+  await buildGroupLeaderboard(firstArg);
+}
+
+main().catch((error) => {
+  console.error('❌ Failed to build leaderboard aggregate:', error);
+  process.exit(1);
+});

--- a/scripts/export-match-predictions.ts
+++ b/scripts/export-match-predictions.ts
@@ -1,0 +1,93 @@
+import admin from 'firebase-admin';
+import dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+dotenv.config({ quiet: true });
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_GROUP_ID = 'LxlkofzvAVMRS2dplF7Z';
+const DEFAULT_MATCH_ID = 'match-031-BRAvsHAI';
+
+const groupId = process.argv[2] ?? DEFAULT_GROUP_ID;
+const matchId = process.argv[3] ?? DEFAULT_MATCH_ID;
+const projectId = process.env.PUBLIC_FIREBASE_PROJECT_ID ?? process.env.VITE_FIREBASE_PROJECT_ID;
+
+if (!projectId) {
+  console.error('PUBLIC_FIREBASE_PROJECT_ID or VITE_FIREBASE_PROJECT_ID is missing.');
+  process.exit(1);
+}
+
+function loadServiceAccount(): admin.ServiceAccount {
+  const credentialPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  if (credentialPath) {
+    return JSON.parse(readFileSync(credentialPath, 'utf8')) as admin.ServiceAccount;
+  }
+
+  return JSON.parse(readFileSync(join(__dirname, 'service-account-key.json'), 'utf8')) as admin.ServiceAccount;
+}
+
+function toJsonValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (value instanceof admin.firestore.Timestamp) {
+    return value.toDate().toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(toJsonValue);
+  }
+
+  if (typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      output[key] = toJsonValue(nestedValue);
+    }
+    return output;
+  }
+
+  return value;
+}
+
+if (admin.apps.length === 0) {
+  admin.initializeApp({
+    credential: admin.credential.cert(loadServiceAccount()),
+    projectId,
+  });
+}
+
+const db = admin.firestore();
+
+async function main() {
+  const snapshot = await db
+    .collection('groups')
+    .doc(groupId)
+    .collection('predictions')
+    .where('matchId', '==', matchId)
+    .get();
+
+  const predictions = snapshot.docs
+    .map((doc) => toJsonValue({ id: doc.id, ...doc.data() }))
+    .sort((a, b) => {
+      const userA = String((a as { userId?: unknown }).userId ?? '');
+      const userB = String((b as { userId?: unknown }).userId ?? '');
+      return userA.localeCompare(userB);
+    });
+
+  const output = {
+    groupId,
+    matchId,
+    count: predictions.length,
+    predictions,
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/update-mundial-players.ts
+++ b/scripts/update-mundial-players.ts
@@ -1,0 +1,338 @@
+/**
+ * Actualiza (upsert) jugadores destacados para Mundial 2026.
+ *
+ * - Lee equipos existentes en `competitions/{competitionId}/teams`
+ * - Escribe jugadores en `competitions/{competitionId}/players`
+ * - Opcionalmente elimina jugadores no incluidos (prune)
+ *
+ * Uso:
+ *   npx tsx scripts/update-mundial-players.ts
+ *   npx tsx scripts/update-mundial-players.ts --competitionId=mundial-2026
+ *   npx tsx scripts/update-mundial-players.ts --dry-run
+ *   npx tsx scripts/update-mundial-players.ts --prune
+ */
+import admin from 'firebase-admin';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { readFileSync } from 'fs';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ==============================
+// Configuración Firebase Admin
+// ==============================
+const projectId = process.env.PUBLIC_FIREBASE_PROJECT_ID;
+
+if (!projectId) {
+  console.error('❌ Error: PUBLIC_FIREBASE_PROJECT_ID is missing. Please check your .env file.');
+  process.exit(1);
+}
+
+const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+let serviceAccount: any = null;
+
+if (serviceAccountPath) {
+  try {
+    const fileContent = readFileSync(serviceAccountPath, 'utf8');
+    serviceAccount = JSON.parse(fileContent);
+    console.log('✅ Usando credenciales de servicio desde GOOGLE_APPLICATION_CREDENTIALS');
+  } catch {
+    console.warn('⚠️  No se pudo cargar el archivo de credenciales desde GOOGLE_APPLICATION_CREDENTIALS');
+  }
+}
+
+if (!serviceAccount) {
+  try {
+    const keyPath = join(__dirname, 'service-account-key.json');
+    const fileContent = readFileSync(keyPath, 'utf8');
+    serviceAccount = JSON.parse(fileContent);
+    console.log('✅ Usando credenciales de servicio desde scripts/service-account-key.json');
+  } catch {
+    console.error('❌ Error: No se encontraron credenciales de servicio.');
+    console.error('   Configura GOOGLE_APPLICATION_CREDENTIALS o coloca service-account-key.json en scripts/');
+    process.exit(1);
+  }
+}
+
+if (admin.apps.length === 0) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    projectId
+  });
+}
+
+const db = admin.firestore();
+
+// ==============================
+// CLI args
+// ==============================
+function parseArgs(argv: string[]) {
+  const args: Record<string, string | boolean> = {};
+  for (const raw of argv) {
+    if (!raw.startsWith('--')) continue;
+    const s = raw.slice(2);
+    const eq = s.indexOf('=');
+    if (eq === -1) {
+      args[s] = true;
+      continue;
+    }
+    args[s.slice(0, eq)] = s.slice(eq + 1);
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const competitionId =
+  (typeof args.competitionId === 'string' && args.competitionId) || 'mundial-2026';
+const dryRun = args['dry-run'] === true || args.dryRun === true;
+const prune = args.prune === true;
+
+// ==============================
+// Datos de jugadores
+// ==============================
+interface MundialPlayer {
+  name: string;
+  teamName: string;
+  position: string;
+}
+
+const MUNDIAL_PLAYERS_RAW: MundialPlayer[] = [
+  // Goleadores
+  { name: 'Jonathan David', teamName: 'Canadá', position: 'Delantero' },
+  { name: 'Lionel Messi', teamName: 'Argentina', position: 'Delantero' },
+  { name: 'Cyle Larin', teamName: 'Canadá', position: 'Delantero' },
+  { name: 'Johan Manzambi', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Yasin Ayari', teamName: 'Suecia', position: 'Delantero' },
+  { name: 'Elijah Just', teamName: 'Nueva Zelanda', position: 'Delantero' },
+  { name: 'Erling Haaland', teamName: 'Noruega', position: 'Delantero' },
+  { name: 'Kylian Mbappé', teamName: 'Francia', position: 'Delantero' },
+  { name: 'Kai Havertz', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Harry Kane', teamName: 'Inglaterra', position: 'Delantero' },
+  { name: 'Folarin Balogun', teamName: 'Estados Unidos', position: 'Delantero' },
+  { name: 'Teboho Mokoena', teamName: 'Sudáfrica', position: 'Delantero' },
+  { name: 'Ladislav Krejcí', teamName: 'Chequia', position: 'Delantero' },
+  { name: 'Granit Xhaka', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Breel Embolo', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Hwang In-Beom', teamName: 'Corea del Sur', position: 'Delantero' },
+  { name: 'Julián Quiñones', teamName: 'México', position: 'Delantero' },
+  { name: 'Raúl Jiménez', teamName: 'México', position: 'Delantero' },
+  { name: 'Rubén Vargas', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Michal Sadílek', teamName: 'Chequia', position: 'Delantero' },
+  { name: 'Jovo Lukic', teamName: 'Bosnia y Herzegovina', position: 'Delantero' },
+  { name: 'Oh Hyeon-Gyu', teamName: 'Corea del Sur', position: 'Delantero' },
+  { name: 'Caleb Yirenkyi', teamName: 'Ghana', position: 'Delantero' },
+  { name: 'João Neves', teamName: 'Portugal', position: 'Delantero' },
+  { name: 'Ali Olwan', teamName: 'Jordania', position: 'Delantero' },
+  { name: 'Livano Comenencia', teamName: 'Curacao', position: 'Delantero' },
+  { name: 'Omar Rekik', teamName: 'Túnez', position: 'Delantero' },
+  { name: 'Mohammad Mohebbi', teamName: 'Irán', position: 'Delantero' },
+  { name: 'Nico Schlotterbeck', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Keito Nakamura', teamName: 'Japón', position: 'Delantero' },
+  { name: 'Connor Metcalfe', teamName: 'Australia', position: 'Delantero' },
+  { name: 'Viktor Gyökeres', teamName: 'Suecia', position: 'Delantero' },
+  { name: 'Abdulelah Al-Amri', teamName: 'Arabia Saudita', position: 'Delantero' },
+  { name: 'Vinícius Júnior', teamName: 'Brasil', position: 'Delantero' },
+  { name: 'Aymen Hussein', teamName: 'Irak', position: 'Delantero' },
+  { name: 'Yoane Wissa', teamName: 'República Democrática del Congo', position: 'Delantero' },
+  { name: 'Daichi Kamada', teamName: 'Japón', position: 'Delantero' },
+  { name: 'Ramin Rezaeian', teamName: 'Irán', position: 'Delantero' },
+  { name: 'Virgil van Dijk', teamName: 'Países Bajos', position: 'Delantero' },
+  { name: 'Daniel Muñoz', teamName: 'Colombia', position: 'Delantero' },
+  { name: 'Ismael Saibari', teamName: 'Marruecos', position: 'Delantero' },
+  { name: 'Luis Díaz', teamName: 'Colombia', position: 'Delantero' },
+  { name: 'Alexander Isak', teamName: 'Suecia', position: 'Delantero' },
+  { name: 'Romano Schmid', teamName: 'Austria', position: 'Delantero' },
+  { name: 'John McGinn', teamName: 'Escocia', position: 'Delantero' },
+  { name: 'Maxi Araújo', teamName: 'Uruguay', position: 'Delantero' },
+  { name: 'Jude Bellingham', teamName: 'Inglaterra', position: 'Delantero' },
+  { name: 'Martin Baturina', teamName: 'Croacia', position: 'Delantero' },
+  { name: 'Abbosbek Fayzullaev', teamName: 'Uzbekistán', position: 'Delantero' },
+  { name: 'Felix Nmecha', teamName: 'Alemania', position: 'Delantero' },
+
+  // Asistencias
+  { name: 'Chris Wood', teamName: 'Nueva Zelanda', position: 'Delantero' },
+  { name: 'Alexander Isak', teamName: 'Suecia', position: 'Delantero' },
+  { name: 'Joshua Kimmich', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Ryan Gravenberch', teamName: 'Países Bajos', position: 'Delantero' },
+  { name: 'Deniz Undav', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Lee Kang-In', teamName: 'Corea del Sur', position: 'Delantero' },
+  { name: 'Vladimír Coufal', teamName: 'Chequia', position: 'Delantero' },
+  { name: 'Breel Embolo', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Hwang In-Beom', teamName: 'Corea del Sur', position: 'Delantero' },
+  { name: 'Sead Kolasinac', teamName: 'Bosnia y Herzegovina', position: 'Delantero' },
+  { name: 'Roberto Alvarado', teamName: 'México', position: 'Delantero' },
+  { name: 'Érik Lira', teamName: 'México', position: 'Delantero' },
+  { name: 'Alexandr Sojka', teamName: 'Chequia', position: 'Delantero' },
+  { name: 'Rubén Vargas', teamName: 'Suiza', position: 'Delantero' },
+  { name: 'Petar Sucic', teamName: 'Croacia', position: 'Delantero' },
+  { name: 'Amir Al-Ammari', teamName: 'Irak', position: 'Delantero' },
+  { name: 'Florian Wirtz', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Hannibal Mejbri', teamName: 'Túnez', position: 'Delantero' },
+  { name: 'Noor Al-Rawabdeh', teamName: 'Jordania', position: 'Delantero' },
+  { name: 'Michael Olise', teamName: 'Francia', position: 'Delantero' },
+  { name: 'Wilfried Singo', teamName: 'Costa de Marfil', position: 'Delantero' },
+  { name: 'Viktor Gyökeres', teamName: 'Suecia', position: 'Delantero' },
+  { name: 'Alex Freeman', teamName: 'Estados Unidos', position: 'Delantero' },
+  { name: 'Elliot Anderson', teamName: 'Inglaterra', position: 'Delantero' },
+  { name: 'Ramin Rezaeian', teamName: 'Irán', position: 'Delantero' },
+  { name: 'Adrien Rabiot', teamName: 'Francia', position: 'Delantero' },
+  { name: 'Rodrigo De Paul', teamName: 'Argentina', position: 'Delantero' },
+  { name: 'Ivan Perisic', teamName: 'Croacia', position: 'Delantero' },
+  { name: 'Julio Enciso', teamName: 'Paraguay', position: 'Delantero' },
+  { name: 'Luis Díaz', teamName: 'Colombia', position: 'Delantero' },
+  { name: 'Paul Okon-Engstler', teamName: 'Australia', position: 'Delantero' },
+  { name: 'Malik Tillman', teamName: 'Estados Unidos', position: 'Delantero' },
+  { name: 'Martin Ødegaard', teamName: 'Noruega', position: 'Delantero' },
+  { name: 'Gustavo Puerta', teamName: 'Colombia', position: 'Delantero' },
+  { name: 'Bruno Guimarães', teamName: 'Brasil', position: 'Delantero' },
+  { name: 'Mohamed Salah', teamName: 'Egipto', position: 'Delantero' },
+  { name: 'Takefusa Kubo', teamName: 'Japón', position: 'Delantero' },
+  { name: 'Arthur Masuaku', teamName: 'República Democrática del Congo', position: 'Delantero' },
+  { name: 'David Møller Wolfe', teamName: 'Noruega', position: 'Delantero' },
+  { name: 'Nathaniel Brown', teamName: 'Alemania', position: 'Delantero' },
+  { name: 'Declan Rice', teamName: 'Inglaterra', position: 'Delantero' },
+  { name: 'Pedro Neto', teamName: 'Portugal', position: 'Delantero' },
+  { name: 'Brahim Díaz', teamName: 'Marruecos', position: 'Delantero' },
+  { name: 'Xaver Schlager', teamName: 'Austria', position: 'Delantero' },
+  { name: 'Christian Pulisic', teamName: 'Estados Unidos', position: 'Delantero' },
+  { name: 'Nico González', teamName: 'Argentina', position: 'Delantero' },
+  { name: 'Nathan Saliba', teamName: 'Canadá', position: 'Delantero' },
+  { name: 'Brandon Thomas-Asante', teamName: 'Ghana', position: 'Delantero' },
+  { name: 'Promise David', teamName: 'Canadá', position: 'Delantero' },
+  { name: 'Lucas Bergvall', teamName: 'Suecia', position: 'Delantero' }
+];
+
+const TEAM_NAME_NORMALIZATION: Record<string, string> = {
+  Curacao: 'Curazao'
+};
+
+function normalizeTeamName(teamName: string): string {
+  return TEAM_NAME_NORMALIZATION[teamName] ?? teamName;
+}
+
+function dedupeByPlayerName(players: MundialPlayer[]): MundialPlayer[] {
+  const byName = new Map<string, MundialPlayer>();
+  for (const player of players) {
+    if (byName.has(player.name)) continue;
+    byName.set(player.name, { ...player, teamName: normalizeTeamName(player.teamName) });
+  }
+  return Array.from(byName.values());
+}
+
+const MUNDIAL_PLAYERS = dedupeByPlayerName(MUNDIAL_PLAYERS_RAW);
+
+function getPlayerDocIdFromName(name: string): string {
+  // Firestore document IDs no pueden tener "/"
+  return name.replace(/\//g, '-');
+}
+
+// ==============================
+// Script principal
+// ==============================
+async function updateMundialPlayers() {
+  console.log(`\n🌍 Actualizando jugadores para "${competitionId}"...\n`);
+  if (dryRun) console.log('🧪 Modo dry-run (no se escribirá nada)\n');
+
+  const competitionRef = db.collection('competitions').doc(competitionId);
+  const teamsSnapshot = await competitionRef.collection('teams').get();
+
+  if (teamsSnapshot.empty) {
+    console.error('❌ No hay equipos en la competición. Crea/seed teams primero.');
+    process.exit(1);
+  }
+
+  const teamIdByName = new Map<string, string>();
+  teamsSnapshot.forEach((d) => {
+    const data = d.data() as { name?: string };
+    if (data?.name) teamIdByName.set(data.name, d.id);
+  });
+
+  const playersRef = competitionRef.collection('players');
+  const wantedIds = new Set<string>();
+
+  let created = 0;
+  let updated = 0;
+  let skippedMissingTeam = 0;
+
+  const BATCH_SIZE = 450;
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const player of MUNDIAL_PLAYERS) {
+    const teamId = teamIdByName.get(player.teamName);
+    if (!teamId) {
+      skippedMissingTeam += 1;
+      console.warn(`⚠️  Equipo "${player.teamName}" no encontrado para jugador ${player.name}`);
+      continue;
+    }
+
+    const playerDocId = getPlayerDocIdFromName(player.name);
+    wantedIds.add(playerDocId);
+    const ref = playersRef.doc(playerDocId);
+
+    if (!dryRun) {
+      const existing = await ref.get();
+      const payload = {
+        name: player.name,
+        teamId,
+        position: player.position,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        ...(existing.exists ? {} : { createdAt: admin.firestore.FieldValue.serverTimestamp() })
+      };
+      batch.set(ref, payload, { merge: true });
+      if (existing.exists) updated += 1;
+      else created += 1;
+    } else {
+      // En dry-run no hacemos lecturas por jugador; mostramos intención.
+      updated += 1;
+    }
+
+    batchCount += 1;
+    if (batchCount >= BATCH_SIZE) {
+      if (!dryRun) await batch.commit();
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  if (batchCount > 0) {
+    if (!dryRun) await batch.commit();
+  }
+
+  let pruned = 0;
+  if (prune) {
+    console.log('\n🧹 Prune habilitado: eliminando jugadores no incluidos en la lista...');
+    const existingPlayers = await playersRef.get();
+    const deletions: admin.firestore.DocumentReference[] = [];
+    existingPlayers.forEach((d) => {
+      if (!wantedIds.has(d.id)) deletions.push(d.ref);
+    });
+
+    const DEL_BATCH_SIZE = 450;
+    for (let i = 0; i < deletions.length; i += DEL_BATCH_SIZE) {
+      const delBatch = db.batch();
+      deletions.slice(i, i + DEL_BATCH_SIZE).forEach((ref) => delBatch.delete(ref));
+      if (!dryRun) await delBatch.commit();
+    }
+
+    pruned = deletions.length;
+  }
+
+  console.log('\n✅ Jugadores actualizados.');
+  console.log(`  - Creados: ${created}`);
+  console.log(`  - Actualizados: ${updated}`);
+  console.log(`  - Omitidos (equipo no encontrado): ${skippedMissingTeam}`);
+  if (prune) console.log(`  - Eliminados (prune): ${pruned}`);
+  console.log('');
+}
+
+updateMundialPlayers()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('❌ Error actualizando jugadores:', error);
+    process.exit(1);
+  });

--- a/src/components/react/GroupDashboard.tsx
+++ b/src/components/react/GroupDashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
 import { getGroup, isGroupAdmin } from '../../lib/groups';
-import { getCurrentUser } from '../../lib/auth';
+import { getCurrentUser, getUserData } from '../../lib/auth';
+import { functions } from '../../lib/firebase';
 import { getRoute } from '../../lib/utils';
 import PredictionsView from './PredictionsView';
 import GroupLeaderboard from './GroupLeaderboard';
@@ -30,6 +32,9 @@ export default function GroupDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [userIsAdmin, setUserIsAdmin] = useState(false);
+  const [userIsSuperAdmin, setUserIsSuperAdmin] = useState(false);
+  const [refreshingLeaderboards, setRefreshingLeaderboards] = useState(false);
+  const [leaderboardMessage, setLeaderboardMessage] = useState('');
   const [paramsChecked, setParamsChecked] = useState(false);
 
   useEffect(() => {
@@ -84,10 +89,31 @@ export default function GroupDashboard() {
 
       setGroup(groupData);
       setUserIsAdmin(isGroupAdmin(groupData, user.uid));
+      const userData = await getUserData(user.uid);
+      setUserIsSuperAdmin(userData?.superAdmin === true);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Error al cargar grupo');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleRefreshLeaderboards = async () => {
+    if (!group) return;
+
+    setRefreshingLeaderboards(true);
+    setLeaderboardMessage('');
+    try {
+      const refreshLeaderboards = httpsCallable<
+        { competitionId: string },
+        { groupsUpdated: number }
+      >(functions, 'refreshLeaderboards');
+      const result = await refreshLeaderboards({ competitionId: group.competitionId });
+      setLeaderboardMessage(`Tablas actualizadas: ${result.data.groupsUpdated} grupos.`);
+    } catch (err: unknown) {
+      setLeaderboardMessage(err instanceof Error ? err.message : 'No se pudieron actualizar las tablas');
+    } finally {
+      setRefreshingLeaderboards(false);
     }
   };
 
@@ -128,9 +154,25 @@ export default function GroupDashboard() {
 
   if (!group) return null;
 
+  const bonusPredictionsHref = (() => {
+    const basePath = getRoute('/groups/dashboard');
+    const params = new URLSearchParams({ groupId, tab: 'predictions', subTab: 'bonus' });
+    return `${basePath}?${params.toString()}`;
+  })();
+
   return (
     <div className="max-w-7xl mx-auto mt-8 p-6 bg-[color:var(--pc-surface)]/40">
       <div className="mb-4 flex justify-end">
+        {userIsSuperAdmin && (
+          <button
+            type="button"
+            onClick={handleRefreshLeaderboards}
+            disabled={refreshingLeaderboards}
+            className="mr-3 inline-flex items-center gap-2 rounded-lg border border-[color:var(--pc-accent)]/60 bg-[color:var(--pc-main)]/30 px-3 py-2 text-sm font-medium text-[color:var(--pc-text-on-dark)] transition hover:border-[color:var(--pc-accent)] disabled:opacity-60"
+          >
+            {refreshingLeaderboards ? 'Actualizando...' : 'Actualizar tablas'}
+          </button>
+        )}
         <a
           href={getRoute('/groups')}
           className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--pc-main-dark)]/60 bg-[color:var(--pc-surface)]/60 px-3 py-2 text-sm font-medium text-[color:var(--pc-muted)] transition hover:border-[color:var(--pc-accent)]/50 hover:text-[color:var(--pc-accent)]"
@@ -139,6 +181,12 @@ export default function GroupDashboard() {
           Volver a mis grupos
         </a>
       </div>
+
+      {leaderboardMessage && (
+        <div className="mb-4 rounded-lg border border-[color:var(--pc-accent)]/50 bg-[color:var(--pc-surface)]/80 px-4 py-3 text-sm text-[color:var(--pc-muted)]">
+          {leaderboardMessage}
+        </div>
+      )}
 
       <div className="mb-6">
         <div className="flex justify-between items-start">
@@ -169,6 +217,30 @@ export default function GroupDashboard() {
               </span>
             )}
           </div>
+        </div>
+      </div>
+
+      <div className="mb-5 overflow-hidden rounded-2xl border border-yellow-300/40 bg-gradient-to-r from-yellow-400/20 via-amber-500/15 to-[color:var(--pc-main)]/20 p-4 shadow-lg shadow-black/10 backdrop-blur-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-yellow-300/20 text-2xl ring-1 ring-yellow-200/40">
+            🏆
+          </div>
+          <div className="flex-1">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-yellow-200">
+                No pierdas tus puntos extra
+              </p>
+              <p className="mt-1 text-base font-medium text-[color:var(--pc-text-on-dark)]">
+                Los pronósticos bonus cierran el <span className="font-bold text-[color:var(--pc-accent)]">27/06/2026</span>. Cargalos a tiempo y peleá cada punto desde el arranque.
+              </p>
+            </div>
+          </div>
+          <a
+            href={bonusPredictionsHref}
+            className="inline-flex w-full items-center justify-center rounded-xl bg-[color:var(--pc-accent)] px-4 py-2.5 text-sm font-bold text-slate-950 shadow-md shadow-yellow-950/20 transition hover:-translate-y-0.5 hover:bg-yellow-300 sm:w-auto"
+          >
+            Ir a pronósticos bonus
+          </a>
         </div>
       </div>
 

--- a/src/components/react/GroupLeaderboard.tsx
+++ b/src/components/react/GroupLeaderboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import { batchGetUsers, getCurrentUser } from '../../lib/auth';
 import { calculateUserTotalPoints, calculatePredictionPoints } from '../../lib/points';
@@ -7,6 +7,14 @@ import PointsHistoryModal from './PointsHistoryModal';
 import type { Group, Match, Prediction, User as UserType } from '../../lib/types';
 import type { GroupLeaderboardEntry } from '../../lib/points';
 import type { BonusPrediction } from '../../lib/types';
+
+interface LeaderboardAggregateEntry extends GroupLeaderboardEntry {
+  avatarUrl?: string;
+}
+
+interface LeaderboardAggregate {
+  entries?: LeaderboardAggregateEntry[];
+}
 
 function getInitial(nameOrEmail: string): string {
   const s = (nameOrEmail || 'U').trim();
@@ -29,7 +37,9 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
   const [error, setError] = useState('');
   const [finishedMatches, setFinishedMatches] = useState<FinishedMatchesData>({ ids: new Set(), map: new Map() });
   const [usersMap, setUsersMap] = useState<Map<string, UserType>>(new Map());
+  const [avatarsByUser, setAvatarsByUser] = useState<Map<string, string>>(new Map());
   const [selectedEntry, setSelectedEntry] = useState<GroupLeaderboardEntry | null>(null);
+  const [loadingHistoryUserId, setLoadingHistoryUserId] = useState<string | null>(null);
   const [predictionsByUser, setPredictionsByUser] = useState<Map<string, Prediction[]>>(new Map());
   const [bonusByUser, setBonusByUser] = useState<Map<string, BonusPrediction>>(new Map());
 
@@ -46,6 +56,49 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
       setError('');
 
       try {
+        const aggregateSnapshot = await getDoc(doc(db, 'groups', groupId, 'leaderboard', 'main'));
+        if (aggregateSnapshot.exists()) {
+          const aggregate = aggregateSnapshot.data() as LeaderboardAggregate;
+          if (Array.isArray(aggregate.entries) && aggregate.entries.length > 0) {
+            console.info('[GroupLeaderboard] Using aggregate leaderboard', {
+              groupId,
+              entries: aggregate.entries.length
+            });
+
+            const entries = aggregate.entries
+              .map((entry, index) => ({
+                userId: entry.userId,
+                userName: entry.userName,
+                totalPoints: Number(entry.totalPoints ?? 0),
+                predictionsCount: Number(entry.predictionsCount ?? 0),
+                rank: Number(entry.rank ?? index + 1)
+              }))
+              .sort((a, b) =>
+                b.totalPoints !== a.totalPoints
+                  ? b.totalPoints - a.totalPoints
+                  : a.userName.localeCompare(b.userName)
+              );
+            entries.forEach((entry, index) => {
+              entry.rank = index + 1;
+            });
+
+            const nextAvatars = new Map<string, string>();
+            aggregate.entries.forEach((entry) => {
+              if (entry.avatarUrl) nextAvatars.set(entry.userId, entry.avatarUrl);
+            });
+
+            setUsersMap(new Map());
+            setAvatarsByUser(nextAvatars);
+            setFinishedMatches({ ids: new Set(), map: new Map() });
+            setPredictionsByUser(new Map());
+            setBonusByUser(new Map());
+            setLeaderboard(entries);
+            return;
+          }
+        }
+
+        console.warn('[GroupLeaderboard] Falling back to full collection scan', { groupId });
+
         const usersPromise = batchGetUsers(allUserIds);
         const matchesPromise = getDocs(
           query(
@@ -78,7 +131,7 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
           if (!finishedIds.has(prediction.matchId)) return;
 
           const match = finishedMap.get(prediction.matchId);
-          if (!prediction.points && match?.result) {
+          if (match?.result) {
             const calculated = calculatePredictionPoints(prediction, match.result, group.settings);
             prediction.points = calculated.points;
             prediction.pointsBreakdown = calculated.breakdown;
@@ -123,6 +176,7 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
         });
 
         setUsersMap(resolvedUsersMap);
+        setAvatarsByUser(new Map());
         setFinishedMatches({ ids: finishedIds, map: finishedMap });
         setPredictionsByUser(nextPredictionsByUser);
         setBonusByUser(nextBonusByUser);
@@ -144,6 +198,101 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
       cancelled = true;
     };
   }, [groupId, group.competitionId, allUserIds.join(','), group.settings]);
+
+  async function openPointsHistory(entry: GroupLeaderboardEntry) {
+    if (predictionsByUser.has(entry.userId) || bonusByUser.has(entry.userId)) {
+      setSelectedEntry(entry);
+      return;
+    }
+
+    setLoadingHistoryUserId(entry.userId);
+    try {
+      const [matchesSnapshot, predictionsSnapshot, bonusSnapshot] = await Promise.all([
+        getDocs(
+          query(
+            collection(db, 'competitions', group.competitionId, 'matches'),
+            where('status', '==', 'finished')
+          )
+        ),
+        getDocs(
+          query(
+            collection(db, 'groups', groupId, 'predictions'),
+            where('userId', '==', entry.userId)
+          )
+        ),
+        getDocs(
+          query(
+            collection(db, 'groups', groupId, 'bonusPredictions'),
+            where('userId', '==', entry.userId)
+          )
+        )
+      ]);
+
+      const finishedMap = new Map<string, Match>();
+      matchesSnapshot.forEach((doc) => {
+        const match = { id: doc.id, ...doc.data() } as Match;
+        finishedMap.set(match.id, match);
+      });
+
+      const predictions: Prediction[] = [];
+      predictionsSnapshot.forEach((doc) => {
+        const prediction = { id: doc.id, ...doc.data() } as Prediction;
+        const match = finishedMap.get(prediction.matchId);
+        if (!match?.result) return;
+        const calculated = calculatePredictionPoints(prediction, match.result, group.settings);
+        prediction.points = calculated.points;
+        prediction.pointsBreakdown = calculated.breakdown;
+        predictions.push(prediction);
+      });
+
+      let bonus: BonusPrediction | undefined;
+      bonusSnapshot.forEach((doc) => {
+        bonus = { id: doc.id, ...doc.data() } as BonusPrediction;
+      });
+
+      const actualTotal =
+        predictions.reduce((sum, prediction) => sum + (prediction.points ?? 0), 0) +
+        (bonus?.points ?? 0);
+
+      if (actualTotal !== entry.totalPoints) {
+        console.warn('[GroupLeaderboard] Aggregate total is stale; updating row locally', {
+          groupId,
+          userId: entry.userId,
+          aggregateTotal: entry.totalPoints,
+          actualTotal
+        });
+
+        setLeaderboard((prev) => {
+          const next = prev.map((item) =>
+            item.userId === entry.userId ? { ...item, totalPoints: actualTotal } : item
+          );
+          next.sort((a, b) =>
+            b.totalPoints !== a.totalPoints
+              ? b.totalPoints - a.totalPoints
+              : a.userName.localeCompare(b.userName)
+          );
+          next.forEach((item, index) => {
+            item.rank = index + 1;
+          });
+          return next;
+        });
+      }
+
+      setFinishedMatches({ ids: new Set(finishedMap.keys()), map: finishedMap });
+      setPredictionsByUser((prev) => new Map(prev).set(entry.userId, predictions));
+      setBonusByUser((prev) => {
+        const next = new Map(prev);
+        if (bonus) next.set(entry.userId, bonus);
+        return next;
+      });
+      setSelectedEntry(entry);
+    } catch (err) {
+      console.error('[GroupLeaderboard] Error loading points history:', err);
+      setError(err instanceof Error ? err.message : 'Error al cargar historial de puntos');
+    } finally {
+      setLoadingHistoryUserId(null);
+    }
+  }
 
   if (loading) {
     return (
@@ -217,11 +366,11 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
                   <div className="flex items-center gap-3">
                     <span className="h-9 w-9 shrink-0 flex items-center justify-center rounded-full overflow-hidden bg-[color:var(--pc-main-dark)]/60 text-[color:var(--pc-muted)] font-semibold text-sm">
                       {(() => {
-                        const user = usersMap.get(entry.userId);
-                        if (user?.avatarUrl) {
+                        const avatarUrl = usersMap.get(entry.userId)?.avatarUrl ?? avatarsByUser.get(entry.userId);
+                        if (avatarUrl) {
                           return (
                             <img
-                              src={user.avatarUrl}
+                              src={avatarUrl}
                               alt=""
                               className="w-full h-full object-cover"
                             />
@@ -236,12 +385,13 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-center">
                   <button
                     type="button"
-                    onClick={() => setSelectedEntry(entry)}
-                    className="inline-flex items-center gap-1.5 text-[color:var(--pc-accent)] hover:text-[color:var(--pc-accent-dark)] focus:outline-none focus:ring-2 focus:ring-[color:var(--pc-accent)] focus:ring-offset-1 rounded"
+                    onClick={() => openPointsHistory(entry)}
+                    disabled={loadingHistoryUserId === entry.userId}
+                    className="inline-flex items-center gap-1.5 text-[color:var(--pc-accent)] hover:text-[color:var(--pc-accent-dark)] focus:outline-none focus:ring-2 focus:ring-[color:var(--pc-accent)] focus:ring-offset-1 rounded disabled:opacity-60"
                     title="Ver historial de puntos"
                   >
                     <span className={`font-bold text-lg ${entry.totalPoints > 0 ? 'text-[color:var(--pc-accent)]' : 'text-[color:var(--pc-muted)]'}`}>
-                      {entry.totalPoints}
+                      {loadingHistoryUserId === entry.userId ? '...' : entry.totalPoints}
                     </span>
                   </button>
                 </td>
@@ -256,7 +406,7 @@ export default function GroupLeaderboard({ groupId, group }: GroupLeaderboardPro
           isOpen={!!selectedEntry}
           onClose={() => setSelectedEntry(null)}
           userName={selectedEntry.userName}
-          avatarUrl={usersMap.get(selectedEntry.userId)?.avatarUrl}
+          avatarUrl={usersMap.get(selectedEntry.userId)?.avatarUrl ?? avatarsByUser.get(selectedEntry.userId)}
           predictions={predictionsByUser.get(selectedEntry.userId) ?? []}
           bonus={bonusByUser.get(selectedEntry.userId)}
           matchesMap={finishedMatches.map}

--- a/src/components/react/PredictionsView.tsx
+++ b/src/components/react/PredictionsView.tsx
@@ -1,4 +1,4 @@
-import { collection, doc, onSnapshot, serverTimestamp, updateDoc } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, onSnapshot, query, serverTimestamp, updateDoc, where } from 'firebase/firestore';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getCurrentUser } from '../../lib/auth';
 import { db } from '../../lib/firebase';
@@ -23,6 +23,22 @@ import BonusPredictionsForm from './BonusPredictionsForm';
 import MatchCard from './MatchCard';
 
 export type PredictionsSubTab = 'live' | 'upcoming' | 'finished' | 'bonus';
+
+function getInitialSubTab(): PredictionsSubTab | null {
+  if (typeof window === 'undefined') return null;
+
+  const requestedSubTab = new URLSearchParams(window.location.search).get('subTab');
+  if (
+    requestedSubTab === 'live' ||
+    requestedSubTab === 'upcoming' ||
+    requestedSubTab === 'finished' ||
+    requestedSubTab === 'bonus'
+  ) {
+    return requestedSubTab;
+  }
+
+  return null;
+}
 
 const FINISHED_MATCH_SORT_STORAGE_KEY = 'pollaClubFinishedMatchSort';
 
@@ -72,16 +88,48 @@ export default function PredictionsView({ groupId, group: groupProp }: Predictio
   useEffect(() => {
     if (!group?.competitionId) return;
 
+    let cancelled = false;
     const matchesRef = collection(db, 'competitions', group.competitionId, 'matches');
-    const unsubscribe = onSnapshot(
-      matchesRef,
-      (snapshot) => {
-        const updatedMatches: Match[] = [];
+    getDocs(matchesRef)
+      .then((snapshot) => {
+        if (cancelled) return;
+        const loadedMatches: Match[] = [];
         snapshot.forEach((doc) => {
-          const matchData = doc.data();
-          updatedMatches.push({ ...matchData, id: doc.id } as Match);
+          loadedMatches.push({ id: doc.id, ...doc.data() } as Match);
         });
-        setMatches(updatedMatches);
+        setMatches(loadedMatches);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('Error al cargar partidos:', err);
+        setError('Error al cargar partidos');
+      });
+
+    const unsubscribe = onSnapshot(
+      query(matchesRef, where('status', '==', 'live')),
+      (snapshot) => {
+        snapshot.docChanges().forEach((change) => {
+          const matchId = change.doc.id;
+          if (change.type === 'removed') {
+            getDoc(doc(db, 'competitions', group.competitionId, 'matches', matchId))
+              .then((freshDoc) => {
+                if (cancelled || !freshDoc.exists()) return;
+                const freshMatch = { id: freshDoc.id, ...freshDoc.data() } as Match;
+                setMatches((prev) => prev.map((match) => match.id === freshMatch.id ? freshMatch : match));
+              })
+              .catch((err) => console.error('Error al refrescar partido finalizado:', err));
+            return;
+          }
+
+          const liveMatch = { id: matchId, ...change.doc.data() } as Match;
+          setMatches((prev) => {
+            const exists = prev.some((match) => match.id === liveMatch.id);
+            if (exists) {
+              return prev.map((match) => match.id === liveMatch.id ? liveMatch : match);
+            }
+            return [...prev, liveMatch];
+          });
+        });
       },
       (err) => {
         console.error('Error en listener de partidos:', err);
@@ -89,7 +137,10 @@ export default function PredictionsView({ groupId, group: groupProp }: Predictio
       }
     );
 
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [group?.competitionId]);
 
   const user = getCurrentUser();
@@ -183,6 +234,88 @@ export default function PredictionsView({ groupId, group: groupProp }: Predictio
     }
   };
 
+  const upcomingMatches = sortMatchesByScheduledTime(filterUpcomingMatches(matches), 'asc');
+  const liveMatches = sortMatchesByScheduledTime(filterLiveMatches(matches), 'asc');
+  const finishedMatches = sortMatchesByScheduledTime(
+    filterFinishedMatches(matches),
+    finishedMatchSortOrder
+  );
+
+  const upcomingDayGroups = useMemo(
+    () => groupMatchesByLocalDayPreservingOrder(upcomingMatches),
+    [upcomingMatches]
+  );
+  const finishedDayGroups = useMemo(
+    () => groupMatchesByLocalDayPreservingOrder(finishedMatches),
+    [finishedMatches]
+  );
+
+  const defaultSubTab: PredictionsSubTab =
+    liveMatches.length > 0 ? 'live' : upcomingMatches.length > 0 ? 'upcoming' : finishedMatches.length > 0 ? 'finished' : 'bonus';
+  const [subTab, setSubTab] = useState<PredictionsSubTab>(() => getInitialSubTab() ?? 'upcoming');
+  const initialDefaultSet = useRef(false);
+
+  useEffect(() => {
+    if (getInitialSubTab()) {
+      initialDefaultSet.current = true;
+      return;
+    }
+
+    if (matches.length > 0 && !initialDefaultSet.current) {
+      initialDefaultSet.current = true;
+      setSubTab(defaultSubTab);
+    }
+  }, [matches.length, defaultSubTab]);
+
+  const setSubTabPersisted = (nextSubTab: PredictionsSubTab) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('subTab', nextSubTab);
+    window.history.pushState({}, '', url.toString());
+    setSubTab(nextSubTab);
+  };
+
+  useEffect(() => {
+    setSubTab((current) => {
+      if (current === 'live' && liveMatches.length === 0) return defaultSubTab;
+      if (current === 'upcoming' && upcomingMatches.length === 0) return defaultSubTab;
+      if (current === 'finished' && finishedMatches.length === 0) return defaultSubTab;
+      return current;
+    });
+  }, [liveMatches.length, upcomingMatches.length, finishedMatches.length, defaultSubTab]);
+
+  const subTabs: { id: PredictionsSubTab; label: string; count?: number }[] = [
+    ...(liveMatches.length > 0 ? [{ id: 'live' as const, label: 'Partidos en vivo', count: liveMatches.length }] : []),
+    { id: 'upcoming', label: 'Próximos partidos', count: upcomingMatches.length },
+    { id: 'finished', label: 'Partidos finalizados', count: finishedMatches.length },
+    { id: 'bonus', label: 'Pronósticos bonus' },
+  ];
+
+  const freeSlots = group ? getFreeSlotCount(group) : 0;
+  const freeAllowedIds = useMemo(() => {
+    if (!group) return null;
+    if (!isFreeSlotPlan(group) || freeSlots <= 0) return null;
+    if (group.freeMatchIds?.length) {
+      return new Set(group.freeMatchIds);
+    }
+    return new Set(computeFreeMatchIds(matches, freeSlots));
+  }, [group, matches, freeSlots]);
+
+  const getLockMessage = (match: Match): string | undefined => {
+    if (!group) return undefined;
+    if (isFreeSlotPlan(group) && freeAllowedIds && !freeAllowedIds.has(match.id)) {
+      return `La prueba gratuita solo incluye ${freeSlots} partidos fijados para este grupo. Actualiza tu plan para seguir pronosticando.`;
+    }
+    const cap = Number(group.maxMatchNumber || 0);
+    if (!isFreeSlotPlan(group) && cap > 0 && match.matchNumber > cap) {
+      return `Tu plan actual permite jugar solo hasta el partido ${cap}. Actualiza tu plan para seguir pronosticando.`;
+    }
+    return undefined;
+  };
+
+  const lockedUpcomingMatches = upcomingMatches.filter((match) => Boolean(getLockMessage(match)));
+  const hasLockedUpcomingMatches = lockedUpcomingMatches.length > 0;
+  const maxMatchNumber = Number(group?.maxMatchNumber || 0);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-64">
@@ -210,74 +343,6 @@ export default function PredictionsView({ groupId, group: groupProp }: Predictio
     );
   }
 
-  const upcomingMatches = sortMatchesByScheduledTime(filterUpcomingMatches(matches), 'asc');
-  const liveMatches = sortMatchesByScheduledTime(filterLiveMatches(matches), 'asc');
-  const finishedMatches = sortMatchesByScheduledTime(
-    filterFinishedMatches(matches),
-    finishedMatchSortOrder
-  );
-
-  const upcomingDayGroups = useMemo(
-    () => groupMatchesByLocalDayPreservingOrder(upcomingMatches),
-    [upcomingMatches]
-  );
-  const finishedDayGroups = useMemo(
-    () => groupMatchesByLocalDayPreservingOrder(finishedMatches),
-    [finishedMatches]
-  );
-
-  const defaultSubTab: PredictionsSubTab =
-    liveMatches.length > 0 ? 'live' : upcomingMatches.length > 0 ? 'upcoming' : finishedMatches.length > 0 ? 'finished' : 'bonus';
-  const [subTab, setSubTab] = useState<PredictionsSubTab>('upcoming');
-  const initialDefaultSet = useRef(false);
-
-  useEffect(() => {
-    if (matches.length > 0 && !initialDefaultSet.current) {
-      initialDefaultSet.current = true;
-      setSubTab(defaultSubTab);
-    }
-  }, [matches.length, defaultSubTab]);
-
-  useEffect(() => {
-    setSubTab((current) => {
-      if (current === 'live' && liveMatches.length === 0) return defaultSubTab;
-      if (current === 'upcoming' && upcomingMatches.length === 0) return defaultSubTab;
-      if (current === 'finished' && finishedMatches.length === 0) return defaultSubTab;
-      return current;
-    });
-  }, [liveMatches.length, upcomingMatches.length, finishedMatches.length, defaultSubTab]);
-
-  const subTabs: { id: PredictionsSubTab; label: string; count?: number }[] = [
-    ...(liveMatches.length > 0 ? [{ id: 'live' as const, label: 'Partidos en vivo', count: liveMatches.length }] : []),
-    { id: 'upcoming', label: 'Próximos partidos', count: upcomingMatches.length },
-    { id: 'finished', label: 'Partidos finalizados', count: finishedMatches.length },
-    { id: 'bonus', label: 'Pronósticos bonus' },
-  ];
-
-  const freeSlots = getFreeSlotCount(group);
-  const freeAllowedIds = useMemo(() => {
-    if (!isFreeSlotPlan(group) || freeSlots <= 0) return null;
-    if (group.freeMatchIds?.length) {
-      return new Set(group.freeMatchIds);
-    }
-    return new Set(computeFreeMatchIds(matches, freeSlots));
-  }, [group, matches, freeSlots]);
-
-  const getLockMessage = (match: Match): string | undefined => {
-    if (isFreeSlotPlan(group) && freeAllowedIds && !freeAllowedIds.has(match.id)) {
-      return `La prueba gratuita solo incluye ${freeSlots} partidos fijados para este grupo. Actualiza tu plan para seguir pronosticando.`;
-    }
-    const cap = Number(group.maxMatchNumber || 0);
-    if (!isFreeSlotPlan(group) && cap > 0 && match.matchNumber > cap) {
-      return `Tu plan actual permite jugar solo hasta el partido ${cap}. Actualiza tu plan para seguir pronosticando.`;
-    }
-    return undefined;
-  };
-
-  const lockedUpcomingMatches = upcomingMatches.filter((match) => Boolean(getLockMessage(match)));
-  const hasLockedUpcomingMatches = lockedUpcomingMatches.length > 0;
-  const maxMatchNumber = Number(group.maxMatchNumber || 0);
-
   return (
     <div className="space-y-4">
       {saveError && (
@@ -292,7 +357,7 @@ export default function PredictionsView({ groupId, group: groupProp }: Predictio
           <button
             key={id}
             type="button"
-            onClick={() => setSubTab(id)}
+            onClick={() => setSubTabPersisted(id)}
             className={`px-3 py-2 text-sm font-medium rounded-t-lg transition ${
               subTab === id
                 ? 'bg-[color:var(--pc-main)] text-[color:var(--pc-text-on-dark)] border-b-2 border-[color:var(--pc-accent)] shadow-sm'

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
+import { getFunctions } from 'firebase/functions';
 import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
@@ -30,6 +31,7 @@ const app = initializeApp(firebaseConfig);
 // Initialize services
 export const db = getFirestore(app);
 export const auth = getAuth(app);
+export const functions = getFunctions(app);
 export const storage = getStorage(app);
 
 export default app;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,7 @@ export interface User {
   avatarUrl?: string;
   groups: string[];
   canCreateGroups: boolean;
+  superAdmin?: boolean;
   purchasedPlanCode?: string;
   purchasedPlanName?: string;
   purchasedMaxParticipants?: number;


### PR DESCRIPTION
…oard with leaderboard refresh functionality

- Implemented  script to read existing teams and upsert players for Mundial 2026.
- Enhanced  to allow super admins to refresh leaderboards with a new button and display messages.
- Updated  to fetch and display user avatars from the aggregate leaderboard.
- Modified  to persist selected sub-tab in the URL and improve match loading logic.
- Added Firebase Functions initialization in  and extended User type to include  property.